### PR TITLE
Fix broken whitespace in icon-wrappers.sass

### DIFF
--- a/vendor/assets/stylesheets/utilities/_icon-wrappers.sass
+++ b/vendor/assets/stylesheets/utilities/_icon-wrappers.sass
@@ -14,20 +14,18 @@
   ```
   as opposed to the old...
 
- ```html_example
+  ```html_example
   <i class='h6 sms-glyph-arrow_triangle-right' style="background-color:red"></i>
   <br>
   <i class='h6 sms-glyph-arrow_triangle-right' style="background-color:red"></i>
   ```
 
-//icon wrap helpers
-
 .icon-wrap-sm
-  height:10px
+  height: 10px
   width: 10px
 .icon-wrap-med
-  height:40px
+  height: 40px
   width: 40px
 .icon-wrap-lrg
-  height:80px
+  height: 80px
   width: 80px


### PR DESCRIPTION
The doc block had a line that was not indented far enough.

Also, the `height:` lines had some strange non-space characters in the indent.

cc @nertzy 
