### PR TITLE
Half sharknado on mobile

### DIFF
--- a/vendor/assets/stylesheets/utilities/_animations.sass
+++ b/vendor/assets/stylesheets/utilities/_animations.sass
@@ -83,15 +83,15 @@
 
 @-webkit-keyframes spin
   0%
-    -webkit-transform: rotateY(0deg)
+    -webkit-transform: translateZ(1000px) rotateY(0deg)
   100%
-    -webkit-transform: rotateY(359deg)
+    -webkit-transform: translateZ(1000px) rotateY(359deg)
 
 @keyframes spin
   0%
-    transform: rotateY(0deg)
+    transform: translateZ(1000px) rotateY(0deg)
   100%
-    transform: rotateY(359deg)
+    transform: translateZ(1000px) rotateY(359deg)
 
 .icon-spin
   -webkit-animation:  2s linear 0s normal none infinite spin
@@ -99,7 +99,7 @@
 
 .icon-spinner
   width: 100px
-  height: 100px
+  height: 120px
   color: darken(white, 5%)
   font-size: 100px
 


### PR DESCRIPTION
### RELATED STORY ### 

__BUG__ - *Half sharknado on mobile*   

\[[#168321921](https://www.pivotaltracker.com/story/show/168321921)\]

### DESCRIPTION ### 

Mobile (and desktop) Safari is clipping half the Sharknado glyph being transformed with rotateY(). Additionally, the glyph is also being slightly clipped at the bottom.

### STEPS TO REPRODUCE ISSUE ### 

1. Go to an agency unlocking request link on mobile
2. Have the page load
3. Observe the sharknado

**Expected**
To see a full sharknado the same way as on desktop

**Actual**
Saw a half sharknado (See comments for screenshot)

### STEPS TO VERIFY ###

1. Update the SMS ng2 package.json to point to the updated sassypam branch and build
2. Go to `http://localhost:3000/ng2/agency_unlocking/X`
3. The sharknado will appear and disappear to be replaced with the message "This request has already been completed"
4. Enable Safari dev tools if needed
5. Inspect the page and find the hidden sharknado element: `body > div > sms > sms-sharknado > div.background-fade.hide`
6. Remove the `hide` class
7. Sharknado should appear normally

<img width="943" alt="Screen Shot 2020-04-10 at 5 48 15 PM" src="https://user-images.githubusercontent.com/711109/79025356-7db90180-7b53-11ea-817d-707d80ecf3b9.png">

### CHANGELIST ### 

 - Changed z transform of spin animation keyframes
 - Increased sharknado glyph height

### REFERENCES ###

[Bug in CSS3 rotateY transition on Safari?](https://stackoverflow.com/a/18167565)