### PR TITLE
Bugfix: Stricter Space Compliance for SASS

### DIFF
--- a/vendor/assets/stylesheets/elements/_badges.sass
+++ b/vendor/assets/stylesheets/elements/_badges.sass
@@ -14,15 +14,15 @@
 
 
 .badge
-	background: $pam-blue
-	height: 25px
-	display: inline-block
-	width: 25px
-	border-radius: 25px
-	font-size: 10px
-	line-height: 25px
-	color: white
-	font-weight: bold
-	position: absolute
-	right: 10px
-	text-align: center
+  background: $pam-blue
+  height: 25px
+  display: inline-block
+  width: 25px
+  border-radius: 25px
+  font-size: 10px
+  line-height: 25px
+  color: white
+  font-weight: bold
+  position: absolute
+  right: 10px
+  text-align: center

--- a/vendor/assets/stylesheets/elements/_tag.sass
+++ b/vendor/assets/stylesheets/elements/_tag.sass
@@ -11,8 +11,8 @@
   ```
 
 .tag
-	display: inline-block
-	background: $lightest-grey
-	color: white
-	width: auto
-	letter-spacing: .1em
+  display: inline-block
+  background: $lightest-grey
+  color: white
+  width: auto
+  letter-spacing: .1em


### PR DESCRIPTION
## Bugfix: Stricter Space Compliance for SASS
- remove tabs and replace with spaces for stricter SASS compliance
- fixes errors when compiling with dart sass (problem does not occur with node sass) 